### PR TITLE
Support the Apple LLVM to compile Microdict on OSX

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,24 @@
 environment:
   matrix:
+    - APPVEYOR_BUILD_WORKER_IMAGE: macos
+      APPVEYOR_JOB_NAME: "macos-clang"
+      CIBW_BUILD: "cp35-macosx_x86_64 cp36-macosx_x86_64 cp37-macosx_x86_64 cp38-macosx_x86_64 cp39-macosx_x86_64"
+      CC: clang
+      CIBW_TEST_COMMAND: python {project}/microdict/run_tests.py
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
       APPVEYOR_JOB_NAME: "python37-x64-ubuntu"
       CIBW_BUILD: "cp35-manylinux_* cp36-manylinux_* cp37-manylinux_* cp38-manylinux_* cp39-manylinux_*"
+      CC: gcc
       CIBW_TEST_COMMAND: python {project}/microdict/run_tests.py 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       APPVEYOR_JOB_NAME: "python37-x64-vs2019"
       CIBW_BUILD: "cp35-win* cp36-win* cp37-win* cp38-win* cp39-win*"
+      CC: gcc
       CIBW_TEST_COMMAND: python {project}\microdict\run_tests.py 
     - APPVEYOR_BUILD_WORKER_IMAGE: macos
       APPVEYOR_JOB_NAME: "python37-x64-macos"
       CIBW_BUILD: "cp35-macosx_x86_64 cp36-macosx_x86_64 cp37-macosx_x86_64 cp38-macosx_x86_64 cp39-macosx_x86_64"
+      CC: gcc
       CIBW_TEST_COMMAND: python {project}/microdict/run_tests.py 
 
 stack: python 3.7

--- a/microdict/_string.h
+++ b/microdict/_string.h
@@ -28,7 +28,7 @@ typedef kbox_t vbox_t;
 
 #include "hash_funcs.h"
 
-inline uint64_t _hash_func(h_t *h, kbox_t key_box);
+static inline uint64_t _hash_func(h_t *h, kbox_t key_box);
 
 void print_str(char* str, int len){
     printf("Str of len: %d ---", len);

--- a/microdict/mdict_ht.h
+++ b/microdict/mdict_ht.h
@@ -211,7 +211,7 @@ inline void rehash_int(h_t* h, i_t* new_flags, i_t* new_psl, i_t new_num_buckets
 
 
 
-inline int mdict_set(h_t *h, kbox_t key_box, vbox_t val_box) 
+static inline int mdict_set(h_t *h, kbox_t key_box, vbox_t val_box)
 {																	
 	i_t x;														
 
@@ -265,7 +265,7 @@ inline int mdict_set(h_t *h, kbox_t key_box, vbox_t val_box)
 
 
 
-inline int mdict_del_map(h_t *h, kbox_t key_box, vbox_t* val_box) {
+static inline int mdict_del_map(h_t *h, kbox_t key_box, vbox_t* val_box) {
 	i_t idx;
 
 	if (val_box == NULL)

--- a/microdict/str_str_wyhash.h
+++ b/microdict/str_str_wyhash.h
@@ -1,7 +1,7 @@
 #include "wyhash.h"
 #include "_string.h"
 
-inline uint64_t _hash_func(h_t *h, kbox_t key_box) {
+static inline uint64_t _hash_func(h_t *h, kbox_t key_box) {
 	return wyhash(key_box.str, key_box.len, h->seed, _wyp);
 }
 

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,6 @@ def read(filename):
     return open(os.path.join(os.path.dirname(__file__), filename)).read()
 
 if os.name != 'nt':
-    if sys.platform == 'darwin' and 'APPVEYOR' in os.environ:
-        os.environ['CC'] = 'gcc-8'
-
     module_i32_i32 = Extension('i32_i32', sources = [os.path.join(parent_dir, 'int32_int32_Py.c')], extra_compile_args = ["-O3", "-w"])
     module_i32_i64 = Extension('i32_i64', sources = [os.path.join(parent_dir, 'int32_int64_Py.c')], extra_compile_args = ["-O3", "-w"])
     module_i64_i32 = Extension('i64_i32', sources = [os.path.join(parent_dir, 'int64_int32_Py.c')], extra_compile_args = ["-O3", "-w"])


### PR DESCRIPTION
**Problem**:
Unfortunately, microdict package cannot be compiled by Apple's LLVM. I tried the bash one-liner `python3 setup.py install && python3 -c 'from microdict import mdict'` running at microdict's root dir on OSX for old clang v10.0.1 and recent clang v12.0.0 and failed.
I implemented the AppVeyor job for this case. You can see its traceback below:
```
Traceback (most recent call last):
  File "/Users/appveyor/projects/microdict/microdict/run_tests.py", line 1, in <module>
    import microdict.microdict_tests.test_int as mtest_int 
  File "/private/var/folders/5s/g225f6nd6jl4g8tshbh1ltk40000gn/T/tmp4n3ddnun/lib/python3.5/site-packages/microdict/microdict_tests/test_int.py", line 3, in <module>
    from microdict import mdict
  File "/private/var/folders/5s/g225f6nd6jl4g8tshbh1ltk40000gn/T/tmp4n3ddnun/lib/python3.5/site-packages/microdict/mdict.py", line 1, in <module>
    from _mdict_c import i32_i32, i32_i64, i64_i32, i64_i64, str_str
ImportError: dlopen(/private/var/folders/5s/g225f6nd6jl4g8tshbh1ltk40000gn/T/tmp4n3ddnun/lib/python3.5/site-packages/_mdict_c/str_str.cpython-35m-darwin.so, 2): Symbol not found: __hash_func
  Referenced from: /private/var/folders/5s/g225f6nd6jl4g8tshbh1ltk40000gn/T/tmp4n3ddnun/lib/python3.5/site-packages/_mdict_c/str_str.cpython-35m-darwin.so
  Expected in: flat namespace
 in /private/var/folders/5s/g225f6nd6jl4g8tshbh1ltk40000gn/T/tmp4n3ddnun/lib/python3.5/site-packages/_mdict_c/str_str.cpython-35m-darwin.so
Traceback (most recent call last):
  File "/Users/appveyor/.localpython3.7.9/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/Users/appveyor/.localpython3.7.9/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/appveyor/venv3.7.9/lib/python3.7/site-packages/cibuildwheel/__main__.py", line 319, in <module>
    main()
  File "/Users/appveyor/venv3.7.9/lib/python3.7/site-packages/cibuildwheel/__main__.py", line 238, in main
    cibuildwheel.macos.build(build_options)
  File "/Users/appveyor/venv3.7.9/lib/python3.7/site-packages/cibuildwheel/macos.py", line 273, in build
    call(test_command_prepared, cwd=os.environ['HOME'], env=virtualenv_env, shell=True)
  File "/Users/appveyor/venv3.7.9/lib/python3.7/site-packages/cibuildwheel/macos.py", line 24, in call
    return subprocess.check_call(args, env=env, cwd=cwd, shell=shell)
  File "/Users/appveyor/.localpython3.7.9/lib/python3.7/subprocess.py", line 363, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command 'python /Users/appveyor/projects/microdict/microdict/run_tests.py' returned non-zero exit status 1.
``` 

**Solution**:
This PR fixes the exception above just by adding `static` specifier for declared-as-`inline` functions to force C99/C11 compilers to use internal linkage for them.
This works for GNU99 compilers as well because all such `inline` functions are used each in a single translation unit only.