### PR TITLE
Build wheels for all versions of Python

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,26 +1,26 @@
 environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
-      APPVEYOR_JOB_NAME: "python37-x64-ubuntu"
-      CIBW_BUILD: "cp35-manylinux_* cp36-manylinux_* cp37-manylinux_* cp38-manylinux_* cp39-manylinux_*"
-      CIBW_TEST_COMMAND: python {project}/microdict/run_tests.py 
+      APPVEYOR_JOB_NAME: "python311-x64-ubuntu"
+      CIBW_BUILD: "*-manylinux_*"
+      CIBW_TEST_COMMAND: python {project}/microdict/run_tests.py
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      APPVEYOR_JOB_NAME: "python37-x64-vs2019"
-      CIBW_BUILD: "cp35-win* cp36-win* cp37-win* cp38-win* cp39-win*"
-      CIBW_TEST_COMMAND: python {project}\microdict\run_tests.py 
+      APPVEYOR_JOB_NAME: "python311-x64-vs2019"
+      CIBW_BUILD: "*-win*"
+      CIBW_TEST_COMMAND: python {project}\microdict\run_tests.py
     - APPVEYOR_BUILD_WORKER_IMAGE: macos
-      APPVEYOR_JOB_NAME: "python37-x64-macos"
-      CIBW_BUILD: "cp35-macosx_x86_64 cp36-macosx_x86_64 cp37-macosx_x86_64 cp38-macosx_x86_64 cp39-macosx_x86_64"
-      CIBW_TEST_COMMAND: python {project}/microdict/run_tests.py 
+      APPVEYOR_JOB_NAME: "python311-x64-macos"
+      CIBW_BUILD: "*-macosx_x86_64"
+      CIBW_TEST_COMMAND: python {project}/microdict/run_tests.py
 
-stack: python 3.7
+stack: python 3.11
 
 init:
-- cmd: set PATH=C:\Python37;C:\Python37\Scripts;%PATH%
+  - cmd: set PATH=C:\Python311;C:\Python311\Scripts;%PATH%
 
-install: python -m pip install cibuildwheel==1.6.4
+install: python -m pip install -U cibuildwheel
 
-build_script: 
+build_script:
   - python -m cibuildwheel --output-dir wheelhouse
 
 artifacts:


### PR DESCRIPTION
Opens the AppVeyor CI config to build wheels for all versions of Python.

Tested [here](https://ci.appveyor.com/project/daijro/microdict-patch/builds/47943637).